### PR TITLE
Fix bug icon not showing up when deployed through cocoa pods

### DIFF
--- a/BugHunt/Components/Overlay/EBHOverlayView.m
+++ b/BugHunt/Components/Overlay/EBHOverlayView.m
@@ -51,7 +51,11 @@ static const CGFloat kOverlayResistanceDefault = 25.0;
     self.layer.cornerRadius = self.frame.size.height / 2.0f;
     
     UIImageView *imageView = ({
-        UIImage *bugImage = [UIImage imageNamed:@"ebb_icon-bug"];
+        
+        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+        NSString *imagePath = [bundle pathForResource:@"ebb_icon-bug" ofType:@"png"];
+        UIImage *bugImage = [UIImage imageWithContentsOfFile:imagePath];
+        
         UIImageView *imageView = [[UIImageView alloc] initWithImage:bugImage];
         CGRect frame = self.frame;
         frame.origin.x = 0.0f;


### PR DESCRIPTION
Load Bug Image from bundle instead of default bundle, which in the case of cocoapods stops being correct.